### PR TITLE
remove ambiguous conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ endif()
 
 CPMAddPackage(
   NAME sol2
-  URL https://github.com/ThePhD/sol2/archive/v3.2.0.zip
+  URL https://github.com/ThePhD/sol2/archive/v3.2.1.zip
   VERSION 3.2.1
   DOWNLOAD_ONLY YES
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ endif()
 CPMAddPackage(
   NAME sol2
   URL https://github.com/ThePhD/sol2/archive/v3.2.0.zip
-  VERSION 3.2.0
+  VERSION 3.2.1
   DOWNLOAD_ONLY YES
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 # ---- Project ----
 
 project(LuaGlue
-  VERSION 1.2.2
+  VERSION 1.2.3
   LANGUAGES CXX C
 )
 

--- a/source/state.cpp
+++ b/source/state.cpp
@@ -160,7 +160,8 @@ namespace glue {
 
       struct AnyToSolVisitor
           : revisited::RecursiveVisitor<
-                const int &, const size_t &, double, bool, const std::string &, std::string,
+                const short &, const unsigned short &, const int &, const unsigned int &,
+                const long &, const unsigned long &, double, bool, const std::string &, std::string,
                 AnyFunction, const glue::Map &, const LuaMap &, const LuaFunction &, sol::object> {
         lua_State *state;
         sol::object result;
@@ -173,12 +174,32 @@ namespace glue {
           return true;
         }
 
+        bool visit(const short &v) override {
+          result = sol::make_object(state, v);
+          return true;
+        }
+
+        bool visit(const unsigned short &v) override {
+          result = sol::make_object(state, v);
+          return true;
+        }
+
         bool visit(const int &v) override {
           result = sol::make_object(state, v);
           return true;
         }
 
-        bool visit(const size_t &v) override {
+        bool visit(const unsigned int &v) override {
+          result = sol::make_object(state, v);
+          return true;
+        }
+
+        bool visit(const long &v) override {
+          result = sol::make_object(state, v);
+          return true;
+        }
+
+        bool visit(const unsigned long &v) override {
           result = sol::make_object(state, v);
           return true;
         }

--- a/source/state.cpp
+++ b/source/state.cpp
@@ -159,10 +159,9 @@ namespace glue {
       }
 
       struct AnyToSolVisitor
-          : revisited::RecursiveVisitor<const int &, const unsigned &, const size_t &, double, bool,
-                                        const std::string &, std::string, AnyFunction,
-                                        const glue::Map &, const LuaMap &, const LuaFunction &,
-                                        sol::object> {
+          : revisited::RecursiveVisitor<
+                const int &, const size_t &, double, bool, const std::string &, std::string,
+                AnyFunction, const glue::Map &, const LuaMap &, const LuaFunction &, sol::object> {
         lua_State *state;
         sol::object result;
         MapCache *cache;
@@ -175,11 +174,6 @@ namespace glue {
         }
 
         bool visit(const int &v) override {
-          result = sol::make_object(state, v);
-          return true;
-        }
-
-        bool visit(const unsigned &v) override {
           result = sol::make_object(state, v);
           return true;
         }

--- a/test/source/state.cpp
+++ b/test/source/state.cpp
@@ -130,7 +130,7 @@ TEST_CASE("Mapped Values") {
   }
 }
 
-TEST_CASE("Passthrough arguments") {
+TEST_CASE("C++ passthrough arguments") {
   glue::lua::State state;
   state.openStandardLibs();
   glue::MapValue root = state.root();
@@ -147,6 +147,19 @@ TEST_CASE("Passthrough arguments") {
   CHECK_NOTHROW(state.run("x = {1,2}; assert(f(x) == x)"));
   CHECK_NOTHROW(state.run("x = function() end; assert(f(x) == x)"));
   CHECK_NOTHROW(state.run("x = nil; assert(f(x) == x)"));
+}
+
+TEST_CASE("Lua passthrough arguments") {
+  glue::lua::State state;
+  auto f = state.get("function(x) return x end").asFunction();
+  auto test = [&](auto v) { CHECK(f(v).template get<decltype(v)>() == v); };
+  test(short(42));
+  test((unsigned short)(43));
+  test(int(44));
+  test((unsigned int)(45));
+  test(long(46));
+  test((unsigned long)(47));
+  test(std::string("48"));
 }
 
 TEST_CASE("Run file") {


### PR DESCRIPTION
On some systems `unsigned` and `size_t` reference the same type.